### PR TITLE
fix: deprecated bgp_base_cidr in direct link service

### DIFF
--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayTemplateGatewayTypeConnectTemplate.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayTemplateGatewayTypeConnectTemplate.java
@@ -68,7 +68,6 @@ public class GatewayTemplateGatewayTypeConnectTemplate extends GatewayTemplate {
      * Instantiates a new builder with required properties.
      *
      * @param bgpAsn the bgpAsn
-     * @param bgpBaseCidr the bgpBaseCidr
      * @param global the global
      * @param metered the metered
      * @param name the name
@@ -76,9 +75,8 @@ public class GatewayTemplateGatewayTypeConnectTemplate extends GatewayTemplate {
      * @param type the type
      * @param port the port
      */
-    public Builder(Long bgpAsn, String bgpBaseCidr, Boolean global, Boolean metered, String name, Long speedMbps, String type, GatewayPortIdentity port) {
+    public Builder(Long bgpAsn, Boolean global, Boolean metered, String name, Long speedMbps, String type, GatewayPortIdentity port) {
       this.bgpAsn = bgpAsn;
-      this.bgpBaseCidr = bgpBaseCidr;
       this.global = global;
       this.metered = metered;
       this.name = name;
@@ -221,8 +219,6 @@ public class GatewayTemplateGatewayTypeConnectTemplate extends GatewayTemplate {
   protected GatewayTemplateGatewayTypeConnectTemplate(Builder builder) {
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.bgpAsn,
       "bgpAsn cannot be null");
-    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.bgpBaseCidr,
-      "bgpBaseCidr cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.global,
       "global cannot be null");
     com.ibm.cloud.sdk.core.util.Validator.notNull(builder.metered,

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/package-info.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/package-info.java
@@ -11,6 +11,6 @@
  * specific language governing permissions and limitations under the License.
  */
 /**
- * Direct Link APIS v1.
+ * Direct Link v1.
  */
 package com.ibm.cloud.networking.direct_link.v1;

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayTemplateGatewayTypeConnectTemplateTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayTemplateGatewayTypeConnectTemplateTest.java
@@ -48,9 +48,9 @@ public class GatewayTemplateGatewayTypeConnectTemplateTest {
 
     GatewayTemplateGatewayTypeConnectTemplate gatewayTemplateGatewayTypeConnectTemplateModel = new GatewayTemplateGatewayTypeConnectTemplate.Builder()
       .bgpAsn(Long.valueOf("64999"))
-      .bgpBaseCidr("10.254.30.76/30")
-      .bgpCerCidr("10.254.30.78/30")
-      .bgpIbmCidr("10.254.30.77/30")
+      .bgpBaseCidr("testString")
+      .bgpCerCidr("169.254.0.10/30")
+      .bgpIbmCidr("169.254.0.9/30")
       .global(true)
       .metered(false)
       .name("myGateway")
@@ -60,9 +60,9 @@ public class GatewayTemplateGatewayTypeConnectTemplateTest {
       .port(gatewayPortIdentityModel)
       .build();
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.bgpAsn(), Long.valueOf("64999"));
-    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.bgpBaseCidr(), "10.254.30.76/30");
-    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.bgpCerCidr(), "10.254.30.78/30");
-    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.bgpIbmCidr(), "10.254.30.77/30");
+    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.bgpBaseCidr(), "testString");
+    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.bgpCerCidr(), "169.254.0.10/30");
+    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.bgpIbmCidr(), "169.254.0.9/30");
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.global(), Boolean.valueOf(true));
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.metered(), Boolean.valueOf(false));
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModel.name(), "myGateway");
@@ -76,9 +76,9 @@ public class GatewayTemplateGatewayTypeConnectTemplateTest {
     GatewayTemplateGatewayTypeConnectTemplate gatewayTemplateGatewayTypeConnectTemplateModelNew = TestUtilities.deserialize(json, GatewayTemplateGatewayTypeConnectTemplate.class);
     assertTrue(gatewayTemplateGatewayTypeConnectTemplateModelNew instanceof GatewayTemplateGatewayTypeConnectTemplate);
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.bgpAsn(), Long.valueOf("64999"));
-    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.bgpBaseCidr(), "10.254.30.76/30");
-    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.bgpCerCidr(), "10.254.30.78/30");
-    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.bgpIbmCidr(), "10.254.30.77/30");
+    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.bgpBaseCidr(), "testString");
+    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.bgpCerCidr(), "169.254.0.10/30");
+    assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.bgpIbmCidr(), "169.254.0.9/30");
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.global(), Boolean.valueOf(true));
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.metered(), Boolean.valueOf(false));
     assertEquals(gatewayTemplateGatewayTypeConnectTemplateModelNew.name(), "myGateway");


### PR DESCRIPTION
## PR summary
deprecated bgp_base_cidr in direct link service

**Fixes:** <! -- link to issue -->

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->