### PR TITLE
fix: publish coverage reports

### DIFF
--- a/modules/coverage-reports/pom.xml
+++ b/modules/coverage-reports/pom.xml
@@ -16,11 +16,12 @@
     <!-- >>> Replace "My Services" with the service category for the project -->
     <name>Networking Coverage Reports</name>
 
+<!--  Need to publish coverage reports since they are last module
     <properties>
-	<!-- There is no need to publish this module's artifacts on maven central -->
         <maven.deploy.skip>true</maven.deploy.skip>
         <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
     </properties>
+ -->
 
     <dependencies>
         <!-- 


### PR DESCRIPTION
This is a workaround to a bug in nexus staging plugin that if
the last plugin is set to not publish, no plugins get published


## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [ ] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [X] Build/CI related changes
- [ ] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [X ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->