### PR TITLE
feat(directlink): Support Secrets Manager CRNs for authentication_key

### DIFF
--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.java
@@ -1,0 +1,90 @@
+/*
+ * (C) Copyright IBM Corp. 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.networking.direct_link.v1.model;
+
+/**
+ * A [Secrets Manager Arbitrary
+ * Secret](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-getting-started).
+ */
+public class AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity extends AuthenticationKeyIdentity {
+
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String crn;
+
+    /**
+     * Instantiates a new Builder from an existing AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity instance.
+     *
+     * @param authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity the instance to initialize the Builder with
+     */
+    public Builder(AuthenticationKeyIdentity authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity) {
+      this.crn = authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.crn;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param crn the crn
+     */
+    public Builder(String crn) {
+      this.crn = crn;
+    }
+
+    /**
+     * Builds a AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.
+     *
+     * @return the new AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity instance
+     */
+    public AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity build() {
+      return new AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity(this);
+    }
+
+    /**
+     * Set the crn.
+     *
+     * @param crn the crn
+     * @return the AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity builder
+     */
+    public Builder crn(String crn) {
+      this.crn = crn;
+      return this;
+    }
+  }
+
+  protected AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity() { }
+
+  protected AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.crn,
+      "crn cannot be null");
+    crn = builder.crn;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+}

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyReference.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyReference.java
@@ -20,6 +20,7 @@ import com.ibm.cloud.sdk.core.service.model.GenericModel;
  * Classes which extend this class:
  * - AuthenticationKeyReferenceKeyProtectAuthenticationKeyReference
  * - AuthenticationKeyReferenceHpcsAuthenticationKeyReference
+ * - AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference
  */
 public class AuthenticationKeyReference extends GenericModel {
 

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference.java
@@ -1,0 +1,24 @@
+/*
+ * (C) Copyright IBM Corp. 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.networking.direct_link.v1.model;
+
+/**
+ * A reference to a [Secrets Manager Arbitrary
+ * Secret](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-getting-started).
+ */
+public class AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference extends AuthenticationKeyReference {
+
+
+  protected AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference() { }
+}

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/CreateGatewayMacsecCakOptions.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/CreateGatewayMacsecCakOptions.java
@@ -35,7 +35,7 @@ public class CreateGatewayMacsecCakOptions extends GenericModel {
   }
 
   protected String id;
-  protected HpcsKeyIdentity key;
+  protected GatewayMacsecCakKeyReference key;
   protected String name;
   protected String session;
 
@@ -44,7 +44,7 @@ public class CreateGatewayMacsecCakOptions extends GenericModel {
    */
   public static class Builder {
     private String id;
-    private HpcsKeyIdentity key;
+    private GatewayMacsecCakKeyReference key;
     private String name;
     private String session;
 
@@ -74,7 +74,7 @@ public class CreateGatewayMacsecCakOptions extends GenericModel {
      * @param name the name
      * @param session the session
      */
-    public Builder(String id, HpcsKeyIdentity key, String name, String session) {
+    public Builder(String id, GatewayMacsecCakKeyReference key, String name, String session) {
       this.id = id;
       this.key = key;
       this.name = name;
@@ -107,7 +107,7 @@ public class CreateGatewayMacsecCakOptions extends GenericModel {
      * @param key the key
      * @return the CreateGatewayMacsecCakOptions builder
      */
-    public Builder key(HpcsKeyIdentity key) {
+    public Builder key(GatewayMacsecCakKeyReference key) {
       this.key = key;
       return this;
     }
@@ -175,11 +175,12 @@ public class CreateGatewayMacsecCakOptions extends GenericModel {
   /**
    * Gets the key.
    *
-   * A [Hyper Protect Crypto Service Standard Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
+   * The key to use for this MACsec CAK. The key must be a reference to a key in a supported key management service
+   * (HPCS or Secrets Manager).
    *
    * @return the key
    */
-  public HpcsKeyIdentity key() {
+  public GatewayMacsecCakKeyReference key() {
     return key;
   }
 

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReference.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReference.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2025.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -10,28 +10,28 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
+
 package com.ibm.cloud.networking.direct_link.v1.model;
 
 import com.ibm.cloud.sdk.core.service.model.GenericModel;
 
 /**
- * AuthenticationKeyIdentity.
+ * GatewayMacsecCakKeyReference.
  *
  * Classes which extend this class:
- * - AuthenticationKeyIdentityKeyProtectAuthenticationKeyIdentity
- * - AuthenticationKeyIdentityHpcsAuthenticationKeyIdentity
- * - AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity
+ * - GatewayMacsecCakKeyReferenceHpcsCakKeyReference
+ * - GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference
  */
-public class AuthenticationKeyIdentity extends GenericModel {
+public class GatewayMacsecCakKeyReference extends GenericModel {
 
   protected String crn;
 
-  protected AuthenticationKeyIdentity() { }
+  protected GatewayMacsecCakKeyReference() { }
 
   /**
    * Gets the crn.
    *
-   * The CRN of the key.
+   * The CRN of the referenced key.
    *
    * @return the crn
    */
@@ -39,4 +39,3 @@ public class AuthenticationKeyIdentity extends GenericModel {
     return crn;
   }
 }
-

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReferenceHpcsCakKeyReference.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReferenceHpcsCakKeyReference.java
@@ -1,0 +1,90 @@
+/*
+ * (C) Copyright IBM Corp. 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.networking.direct_link.v1.model;
+
+/**
+ * A reference to a [Hyper Protect Crypto Service Standard
+ * Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
+ */
+public class GatewayMacsecCakKeyReferenceHpcsCakKeyReference extends GatewayMacsecCakKeyReference {
+
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String crn;
+
+    /**
+     * Instantiates a new Builder from an existing GatewayMacsecCakKeyReferenceHpcsCakKeyReference instance.
+     *
+     * @param gatewayMacsecCakKeyReferenceHpcsCakKeyReference the instance to initialize the Builder with
+     */
+    public Builder(GatewayMacsecCakKeyReference gatewayMacsecCakKeyReferenceHpcsCakKeyReference) {
+      this.crn = gatewayMacsecCakKeyReferenceHpcsCakKeyReference.crn;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param crn the crn
+     */
+    public Builder(String crn) {
+      this.crn = crn;
+    }
+
+    /**
+     * Builds a GatewayMacsecCakKeyReferenceHpcsCakKeyReference.
+     *
+     * @return the new GatewayMacsecCakKeyReferenceHpcsCakKeyReference instance
+     */
+    public GatewayMacsecCakKeyReferenceHpcsCakKeyReference build() {
+      return new GatewayMacsecCakKeyReferenceHpcsCakKeyReference(this);
+    }
+
+    /**
+     * Set the crn.
+     *
+     * @param crn the crn
+     * @return the GatewayMacsecCakKeyReferenceHpcsCakKeyReference builder
+     */
+    public Builder crn(String crn) {
+      this.crn = crn;
+      return this;
+    }
+  }
+
+  protected GatewayMacsecCakKeyReferenceHpcsCakKeyReference() { }
+
+  protected GatewayMacsecCakKeyReferenceHpcsCakKeyReference(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.crn,
+      "crn cannot be null");
+    crn = builder.crn;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GatewayMacsecCakKeyReferenceHpcsCakKeyReference builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+}

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.java
@@ -1,0 +1,90 @@
+/*
+ * (C) Copyright IBM Corp. 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.networking.direct_link.v1.model;
+
+/**
+ * A reference to a [Secrets Manager Arbitrary
+ * Secret](https://cloud.ibm.com/docs/secrets-manager?topic=secrets-manager-getting-started).
+ */
+public class GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference extends GatewayMacsecCakKeyReference {
+
+
+  /**
+   * Builder.
+   */
+  public static class Builder {
+    private String crn;
+
+    /**
+     * Instantiates a new Builder from an existing GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference instance.
+     *
+     * @param gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference the instance to initialize the Builder with
+     */
+    public Builder(GatewayMacsecCakKeyReference gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference) {
+      this.crn = gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.crn;
+    }
+
+    /**
+     * Instantiates a new builder.
+     */
+    public Builder() {
+    }
+
+    /**
+     * Instantiates a new builder with required properties.
+     *
+     * @param crn the crn
+     */
+    public Builder(String crn) {
+      this.crn = crn;
+    }
+
+    /**
+     * Builds a GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.
+     *
+     * @return the new GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference instance
+     */
+    public GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference build() {
+      return new GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference(this);
+    }
+
+    /**
+     * Set the crn.
+     *
+     * @param crn the crn
+     * @return the GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference builder
+     */
+    public Builder crn(String crn) {
+      this.crn = crn;
+      return this;
+    }
+  }
+
+  protected GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference() { }
+
+  protected GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference(Builder builder) {
+    com.ibm.cloud.sdk.core.util.Validator.notNull(builder.crn,
+      "crn cannot be null");
+    crn = builder.crn;
+  }
+
+  /**
+   * New builder.
+   *
+   * @return a GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference builder
+   */
+  public Builder newBuilder() {
+    return new Builder(this);
+  }
+}

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPatch.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPatch.java
@@ -25,14 +25,14 @@ import com.ibm.cloud.sdk.core.util.GsonSingleton;
  */
 public class GatewayMacsecCakPatch extends GenericModel {
 
-  protected HpcsKeyIdentity key;
+  protected GatewayMacsecCakKeyReference key;
   protected String name;
 
   /**
    * Builder.
    */
   public static class Builder {
-    private HpcsKeyIdentity key;
+    private GatewayMacsecCakKeyReference key;
     private String name;
 
     /**
@@ -66,7 +66,7 @@ public class GatewayMacsecCakPatch extends GenericModel {
      * @param key the key
      * @return the GatewayMacsecCakPatch builder
      */
-    public Builder key(HpcsKeyIdentity key) {
+    public Builder key(GatewayMacsecCakKeyReference key) {
       this.key = key;
       return this;
     }
@@ -102,11 +102,11 @@ public class GatewayMacsecCakPatch extends GenericModel {
   /**
    * Gets the key.
    *
-   * A [Hyper Protect Crypto Service Standard Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
+   * A reference to a key stored in a key management service.
    *
    * @return the key
    */
-  public HpcsKeyIdentity key() {
+  public GatewayMacsecCakKeyReference key() {
     return key;
   }
 

--- a/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPrototype.java
+++ b/modules/direct-link/src/main/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPrototype.java
@@ -34,7 +34,7 @@ public class GatewayMacsecCakPrototype extends GenericModel {
     String FALLBACK = "fallback";
   }
 
-  protected HpcsKeyIdentity key;
+  protected GatewayMacsecCakKeyReference key;
   protected String name;
   protected String session;
 
@@ -42,7 +42,7 @@ public class GatewayMacsecCakPrototype extends GenericModel {
    * Builder.
    */
   public static class Builder {
-    private HpcsKeyIdentity key;
+    private GatewayMacsecCakKeyReference key;
     private String name;
     private String session;
 
@@ -70,7 +70,7 @@ public class GatewayMacsecCakPrototype extends GenericModel {
      * @param name the name
      * @param session the session
      */
-    public Builder(HpcsKeyIdentity key, String name, String session) {
+    public Builder(GatewayMacsecCakKeyReference key, String name, String session) {
       this.key = key;
       this.name = name;
       this.session = session;
@@ -91,7 +91,7 @@ public class GatewayMacsecCakPrototype extends GenericModel {
      * @param key the key
      * @return the GatewayMacsecCakPrototype builder
      */
-    public Builder key(HpcsKeyIdentity key) {
+    public Builder key(GatewayMacsecCakKeyReference key) {
       this.key = key;
       return this;
     }
@@ -145,11 +145,11 @@ public class GatewayMacsecCakPrototype extends GenericModel {
   /**
    * Gets the key.
    *
-   * A [Hyper Protect Crypto Service Standard Key](https://cloud.ibm.com/docs/hs-crypto?topic=hs-crypto-get-started).
+   * A reference to a key stored in a key management service.
    *
    * @return the key
    */
-  public HpcsKeyIdentity key() {
+  public GatewayMacsecCakKeyReference key() {
     return key;
   }
 

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/DirectLinkIT.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/DirectLinkIT.java
@@ -73,7 +73,7 @@ import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayOptions;
 import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayResponse;
 import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayVirtualConnectionOptions;
 import com.ibm.cloud.networking.direct_link.v1.model.GetPortOptions;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.ImportRouteFilterCollection;
 import com.ibm.cloud.networking.direct_link.v1.model.ListGatewayAsPrependsOptions;
 import com.ibm.cloud.networking.direct_link.v1.model.ListGatewayCompletionNoticeOptions;
@@ -125,6 +125,8 @@ import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayExportRouteFilter
 import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayImportRouteFilterOptions;
 import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayMacsecCakOptions;
 import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayMacsecOptions;
+import com.ibm.cloud.networking.direct_link.v1.model.AuthenticationKeyIdentityHpcsAuthenticationKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity;
 import com.ibm.cloud.networking.test.SdkIntegrationTestBase;
 import com.ibm.cloud.sdk.core.http.Response;
 import com.ibm.cloud.sdk.core.util.CredentialUtils;
@@ -1550,14 +1552,14 @@ public class DirectLinkIT extends SdkIntegrationTestBase {
 	// Test setGatewayMacsec
 	@Test(dependsOnMethods = "testConnectGatewayOptions")
 	public void testSetGatewayMacsec() {
-		// Construct an instance of the HpcsKeyIdentity model
-		HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+		// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+		GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
 		.crn("crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:ebc0fbe6-fd7c-4971-b127-71a385c8f602")
 		.build();
-
+	
 		// Construct an instance of the GatewayMacsecCakPrototype model
 		GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-		.key(hpcsKeyIdentityModel)
+		.key(hpcsCakKeyReferenceModel)
 		.name("AA01")
 		.session("primary")
 		.build();
@@ -1625,15 +1627,15 @@ public class DirectLinkIT extends SdkIntegrationTestBase {
 	// Test createGatewayMacsecCak
 	@Test(dependsOnMethods = "testCreateGatewayMacsecCak")
 	public void testCreateGatewayMacsecCak() {
-		// Construct an instance of the HpcsKeyIdentity model
-		HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+		// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+		GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
 		.crn("crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:6f79b964-229c-45ab-b1d9-47e111cd03f6")
 		.build();
 
 		// Construct an instance of the CreateGatewayMacsecCakOptions model
 		CreateGatewayMacsecCakOptions createGatewayMacsecCakOptionsModel = new CreateGatewayMacsecCakOptions.Builder()
 		.id(connectGatewayId)
-		.key(hpcsKeyIdentityModel)
+		.key(hpcsCakKeyReferenceModel)
 		.name("BB02")
 		.session("fallback")
 		.build();
@@ -1669,14 +1671,14 @@ public class DirectLinkIT extends SdkIntegrationTestBase {
 	// Test updateGatewayMacsecCak
 	@Test(dependsOnMethods = "testCreateGatewayMacsecCak")
 	public void testUpdateGatewayMacsecCak() {
-		// Construct an instance of the HpcsKeyIdentity model
-		HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+		// Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+		GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
 		.crn("crn:v1:staging:public:hs-crypto:us-south:a/3f455c4c574447adbc14bda52f80e62f:b2044455-b89e-4c57-96ae-3f17c092dd31:key:6f79b964-229c-45ab-b1d9-47e111cd03f6")
 		.build();
-
+	
 		// Construct an instance of the GatewayMacsecCakPatch model
 		GatewayMacsecCakPatch gatewayMacsecCakPatchModel = new GatewayMacsecCakPatch.Builder()
-		.key(hpcsKeyIdentityModel)
+		.key(hpcsCakKeyReferenceModel)
 		.name("AA02")
 		.build();
 		Map<String, Object> gatewayMacsecCakPatchModelAsPatch = gatewayMacsecCakPatchModel.asPatch();
@@ -1841,82 +1843,154 @@ public class DirectLinkIT extends SdkIntegrationTestBase {
 		assertNotEquals(0,resObj.getSpeeds().size());
 	}
 
-	// @Test()
-	// public void testDirectLinkGatewayWithMD5(){
-	// 	Long timestamp = new Timestamp(System.currentTimeMillis()).getTime(); 
-	// 	assertNotNull(testService);
-	// 	String locationName = config.get("LOCATION_NAME");
-	// 	String gatewayName = "JAVA-INT-SDK-DEDICATED-MD5-"+timestamp; 
-	// 	Long bgpAsn = 64999L; 
-	// 	String bgpBaseCidr = "169.254.0.0/16"; 
-	// 	String crossConnectRouter =	"LAB-xcr01.dal09"; 
-	// 	boolean global = true; 
-	// 	Long speedMbps = 1000L; 
-	// 	boolean metered = false; 
-	// 	String carrierName = "carrier1"; 
-	// 	String customerName = "customer1"; 
-	// 	String gatewayType = "dedicated";
+	@Test()
+	public void testDirectLinkGatewayWithMD5(){
+		Long timestamp = new Timestamp(System.currentTimeMillis()).getTime();
+		assertNotNull(testService);
+		String locationName = config.get("LOCATION_NAME");
+		Long bgpAsn = 64999L;
+		String bgpBaseCidr = "169.254.0.0/16";
+		String crossConnectRouter = "LAB-xcr01.dal09";
+		boolean global = true;
+		Long speedMbps = 1000L;
+		boolean metered = false;
+		String carrierName = "carrier1";
+		String customerName = "customer1";
+		String gatewayType = "dedicated";
 
-	// 	String authenticationCRN = config.get("AUTHENTICATION_KEY");
+		// The AUTHENTICATION_KEY config value holds the CRN for the key (HPCS, Key Protect, or Secrets Manager).
+		// The same config key is reused for all key types; the CRN format identifies the service.
+		String authenticationCRN = config.get("AUTHENTICATION_KEY");
 
-	// 	GatewayTemplateAuthenticationKey authKey = new GatewayTemplateAuthenticationKey.Builder(authenticationCRN).build();
-	  
-	// 	GatewayTemplateGatewayTypeDedicatedTemplate gatewayTemplateModel = new GatewayTemplateGatewayTypeDedicatedTemplate.Builder()
-	// 		.bgpAsn(bgpAsn).bgpBaseCidr(bgpBaseCidr).bgpCerCidr("10.254.30.78/30").bgpIbmCidr("10.254.30.77/30")
-	// 		.global(global).metered(metered).name(gatewayName).speedMbps(speedMbps).type(gatewayType)
-	// 		.carrierName(carrierName).crossConnectRouter(crossConnectRouter).customerName(customerName) 
-	// 		.locationName(locationName).authenticationKey(authKey).build();
-	  
-	//   	// ***************** Create dedicated Gateway ********************* //
-	// 	// Construct an instance of the CreateGatewayOptions model 
-	// 	CreateGatewayOptions createGatewayOptionsModel = new CreateGatewayOptions.Builder().gatewayTemplate(gatewayTemplateModel).build();
-	  
-	// 	// Invoke operation with valid options model (positive test)
-	// 	Response<Gateway> response = testService.createGateway(createGatewayOptionsModel).execute();
-	// 		assertNotNull(response); 
-	// 		assertEquals(201, 
-	// 		response.getStatusCode());
-	  
-	// 	Gateway responseObj = response.getResult(); 
-	// 	assertNotNull(responseObj);
-	// 	assertEquals(responseObj.getName(), gatewayName);
-	// 	assertEquals(responseObj.getAuthenticationKey().getCrn(), authenticationCRN);
-		
-	// 	// save gw id for clean up routine if we terminate
-	//   	gatewayId = responseObj.getId();
-	  
-	// 	// ********** Clear the authentication key using Patch gateway ************* 
-	// 	// Construct an instance of the UpdateGatewayOptions model 
+		// ***************** Test 1: HPCS / Key Protect authentication key ********************* //
+		String gatewayName = "JAVA-INT-SDK-DEDICATED-MD5-"+timestamp;
 
-	// 	GatewayPatchTemplateAuthenticationKey patchAuthKey = new GatewayPatchTemplateAuthenticationKey.Builder("").build();
-	// 	UpdateGatewayOptions updateGatewayOptionsModel = new UpdateGatewayOptions.Builder().id(responseObj.getId())
-	// 		.authenticationKey(patchAuthKey).build();
-			
-	// 	// Invoke operation with valid options model (positive test) 
-	// 	Response<Gateway> updateResponse =	testService.updateGateway(updateGatewayOptionsModel).execute();
-	// 	assertNotNull(updateResponse); 
-	// 	assertEquals(200, updateResponse.getStatusCode());
-	  
-	// 	Gateway updateResponseObj = updateResponse.getResult();
-	// 	assertNotNull(updateResponseObj);
-	// 	assertEquals(updateResponseObj.getId(), gatewayId);
-	// 	assertNull(updateResponseObj.getAuthenticationKey());
-	// 	assertEquals(updateResponseObj.getName(), gatewayName);
+		// Build the authentication key identity using the HPCS subclass
+		AuthenticationKeyIdentityHpcsAuthenticationKeyIdentity authKey =
+			new AuthenticationKeyIdentityHpcsAuthenticationKeyIdentity.Builder(authenticationCRN).build();
 
-	// 	// Delete the dedicated GW 
-	// 	DeleteGatewayOptions deleteGatewayOptionsModel = new DeleteGatewayOptions.Builder().id(gatewayId) .build(); 
-			
-	// 	//  Invoke operation with valid options model (positive test) 
-	// 	Response<Void>  Delresponse = testService.deleteGateway(deleteGatewayOptionsModel).execute();
-	// 	assertNotNull(Delresponse); 
-	// 	assertEquals(204, Delresponse.getStatusCode());
-		
-	// 	Void delResponseObj = Delresponse.getResult(); // Response does not have a return type. Check that the result is null. 
-	// 	assertNull(delResponseObj);
-	  
-	//   	gatewayId = null; // already cleaned up System.out.
+		GatewayTemplateGatewayTypeDedicatedTemplate gatewayTemplateModel = new GatewayTemplateGatewayTypeDedicatedTemplate.Builder()
+			.bgpAsn(bgpAsn).bgpBaseCidr(bgpBaseCidr).bgpCerCidr("10.254.30.86/30").bgpIbmCidr("10.254.30.85/30")
+			.global(global).metered(metered).name(gatewayName).speedMbps(speedMbps).type(gatewayType)
+			.carrierName(carrierName).crossConnectRouter(crossConnectRouter).customerName(customerName)
+			.locationName(locationName).authenticationKey(authKey).build();
 
-	// }
+		// Construct an instance of the CreateGatewayOptions model
+		CreateGatewayOptions createGatewayOptionsModel = new CreateGatewayOptions.Builder().gatewayTemplate(gatewayTemplateModel).build();
+
+		// Invoke operation with valid options model (positive test)
+		Response<Gateway> response = testService.createGateway(createGatewayOptionsModel).execute();
+		assertNotNull(response);
+		assertEquals(201, response.getStatusCode());
+
+		Gateway responseObj = response.getResult();
+		assertNotNull(responseObj);
+		assertEquals(responseObj.getName(), gatewayName);
+		assertEquals(responseObj.getAuthenticationKey().getCrn(), authenticationCRN);
+
+		// save gw id for clean up routine if we terminate
+		gatewayId = responseObj.getId();
+
+		// ********** Clear the HPCS authentication key using Patch gateway *************
+		// Construct an instance of the GatewayPatchTemplate model with null authenticationKey to clear it
+		GatewayPatchTemplate gatewayPatchTemplateModel = new GatewayPatchTemplate.Builder().build();
+		Map<String, Object> gatewayPatchTemplateModelAsPatch = gatewayPatchTemplateModel.asPatch();
+		// Explicitly set authentication_key to null in the patch map to clear it
+		gatewayPatchTemplateModelAsPatch.put("authentication_key", null);
+
+		UpdateGatewayOptions updateGatewayOptionsModel = new UpdateGatewayOptions.Builder()
+			.id(responseObj.getId())
+			.gatewayPatchTemplatePatch(gatewayPatchTemplateModelAsPatch).build();
+
+		// Invoke operation with valid options model (positive test)
+		Response<Gateway> updateResponse = testService.updateGateway(updateGatewayOptionsModel).execute();
+		assertNotNull(updateResponse);
+		assertEquals(200, updateResponse.getStatusCode());
+
+		Gateway updateResponseObj = updateResponse.getResult();
+		assertNotNull(updateResponseObj);
+		assertEquals(updateResponseObj.getId(), gatewayId);
+		assertNull(updateResponseObj.getAuthenticationKey());
+		assertEquals(updateResponseObj.getName(), gatewayName);
+
+		// Delete the dedicated GW
+		DeleteGatewayOptions deleteGatewayOptionsModel = new DeleteGatewayOptions.Builder().id(gatewayId).build();
+
+		// Invoke operation with valid options model (positive test)
+		Response<Void> Delresponse = testService.deleteGateway(deleteGatewayOptionsModel).execute();
+		assertNotNull(Delresponse);
+		assertEquals(204, Delresponse.getStatusCode());
+
+		Void delResponseObj = Delresponse.getResult(); // Response does not have a return type. Check that the result is null.
+		assertNull(delResponseObj);
+
+		gatewayId = null; // already cleaned up
+
+		// ***************** Test 2: Secrets Manager authentication key ********************* //
+		// Reuses the same AUTHENTICATION_KEY config value - the CRN format identifies the key service type.
+		String gatewayNameSM = "JAVA-INT-SDK-DEDICATED-MD5-SM-"+timestamp;
+
+		// Build the authentication key identity using the Secrets Manager subclass
+		AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity smAuthKey =
+			new AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.Builder(authenticationCRN).build();
+
+		GatewayTemplateGatewayTypeDedicatedTemplate gatewayTemplateSMModel = new GatewayTemplateGatewayTypeDedicatedTemplate.Builder()
+			.bgpAsn(bgpAsn).bgpBaseCidr(bgpBaseCidr).bgpCerCidr("10.254.30.90/30").bgpIbmCidr("10.254.30.89/30")
+			.global(global).metered(metered).name(gatewayNameSM).speedMbps(speedMbps).type(gatewayType)
+			.carrierName(carrierName).crossConnectRouter(crossConnectRouter).customerName(customerName)
+			.locationName(locationName).authenticationKey(smAuthKey).build();
+
+		// Construct an instance of the CreateGatewayOptions model
+		CreateGatewayOptions createGatewayOptionsSMModel = new CreateGatewayOptions.Builder().gatewayTemplate(gatewayTemplateSMModel).build();
+
+		// Invoke operation with valid options model (positive test)
+		Response<Gateway> smResponse = testService.createGateway(createGatewayOptionsSMModel).execute();
+		assertNotNull(smResponse);
+		assertEquals(201, smResponse.getStatusCode());
+
+		Gateway smResponseObj = smResponse.getResult();
+		assertNotNull(smResponseObj);
+		assertEquals(smResponseObj.getName(), gatewayNameSM);
+		assertEquals(smResponseObj.getAuthenticationKey().getCrn(), authenticationCRN);
+
+		// save gw id for clean up routine if we terminate
+		gatewayId = smResponseObj.getId();
+
+		// ********** Clear the Secrets Manager authentication key using Patch gateway *************
+		// Construct an instance of the GatewayPatchTemplate model with null authenticationKey to clear it
+		GatewayPatchTemplate smGatewayPatchTemplateModel = new GatewayPatchTemplate.Builder().build();
+		Map<String, Object> smGatewayPatchTemplateModelAsPatch = smGatewayPatchTemplateModel.asPatch();
+		// Explicitly set authentication_key to null in the patch map to clear it
+		smGatewayPatchTemplateModelAsPatch.put("authentication_key", null);
+
+		UpdateGatewayOptions smUpdateGatewayOptionsModel = new UpdateGatewayOptions.Builder()
+			.id(smResponseObj.getId())
+			.gatewayPatchTemplatePatch(smGatewayPatchTemplateModelAsPatch).build();
+
+		// Invoke operation with valid options model (positive test)
+		Response<Gateway> smUpdateResponse = testService.updateGateway(smUpdateGatewayOptionsModel).execute();
+		assertNotNull(smUpdateResponse);
+		assertEquals(200, smUpdateResponse.getStatusCode());
+
+		Gateway smUpdateResponseObj = smUpdateResponse.getResult();
+		assertNotNull(smUpdateResponseObj);
+		assertEquals(smUpdateResponseObj.getId(), gatewayId);
+		assertNull(smUpdateResponseObj.getAuthenticationKey());
+		assertEquals(smUpdateResponseObj.getName(), gatewayNameSM);
+
+		// Delete the dedicated GW
+		DeleteGatewayOptions smDeleteGatewayOptionsModel = new DeleteGatewayOptions.Builder().id(gatewayId).build();
+
+		// Invoke operation with valid options model (positive test)
+		Response<Void> smDelresponse = testService.deleteGateway(smDeleteGatewayOptionsModel).execute();
+		assertNotNull(smDelresponse);
+		assertEquals(204, smDelresponse.getStatusCode());
+
+		Void smDelResponseObj = smDelresponse.getResult(); // Response does not have a return type. Check that the result is null.
+		assertNull(smDelResponseObj);
+
+		gatewayId = null; // already cleaned up
+	}
 	
 	@Test()
 	public void testDirectLinkDedicatedGatewayWithConnectionMode(){

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/DirectLinkTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/DirectLinkTest.java
@@ -109,7 +109,7 @@ import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayStatisticsOptions
 import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayStatusOptions;
 import com.ibm.cloud.networking.direct_link.v1.model.GetGatewayVirtualConnectionOptions;
 import com.ibm.cloud.networking.direct_link.v1.model.GetPortOptions;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.ImportRouteFilterCollection;
 import com.ibm.cloud.networking.direct_link.v1.model.ListGatewayAsPrependsOptions;
@@ -303,14 +303,14 @@ public class DirectLinkTest {
       .id("56969d6043e9465c883cb9f7363e78e8")
       .build();
 
-    // Construct an instance of the HpcsKeyIdentity model
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    // Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
 
     // Construct an instance of the GatewayMacsecCakPrototype model
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
@@ -1939,14 +1939,14 @@ public class DirectLinkTest {
       .setResponseCode(200)
       .setBody(mockResponseBody));
 
-    // Construct an instance of the HpcsKeyIdentity model
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    // Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
 
     // Construct an instance of the GatewayMacsecCakPrototype model
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
@@ -2067,15 +2067,15 @@ public class DirectLinkTest {
       .setResponseCode(201)
       .setBody(mockResponseBody));
 
-    // Construct an instance of the HpcsKeyIdentity model
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    // Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
 
     // Construct an instance of the CreateGatewayMacsecCakOptions model
     CreateGatewayMacsecCakOptions createGatewayMacsecCakOptionsModel = new CreateGatewayMacsecCakOptions.Builder()
       .id("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
@@ -2232,14 +2232,14 @@ public class DirectLinkTest {
       .setResponseCode(200)
       .setBody(mockResponseBody));
 
-    // Construct an instance of the HpcsKeyIdentity model
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    // Construct an instance of the GatewayMacsecCakKeyReferenceHpcsCakKeyReference model
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
 
     // Construct an instance of the GatewayMacsecCakPatch model
     GatewayMacsecCakPatch gatewayMacsecCakPatchModel = new GatewayMacsecCakPatch.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .build();
     Map<String, Object> gatewayMacsecCakPatchModelAsPatch = gatewayMacsecCakPatchModel.asPatch();

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityTest.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright IBM Corp. 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.networking.direct_link.v1.model;
+
+import com.ibm.cloud.networking.direct_link.v1.model.AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity model.
+ */
+public class AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity() throws Throwable {
+    AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityModel = new AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.Builder()
+      .crn("crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222")
+      .build();
+    assertEquals(authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityModel.crn(), "crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222");
+
+    String json = TestUtilities.serialize(authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityModel);
+
+    AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityModelNew = TestUtilities.deserialize(json, AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.class);
+    assertTrue(authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityModelNew instanceof AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity);
+    assertEquals(authenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityModelNew.crn(), "crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testAuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentityError() throws Throwable {
+    new AuthenticationKeyIdentitySecretsManagerAuthenticationKeyIdentity.Builder().build();
+  }
+
+}

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReferenceTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReferenceTest.java
@@ -1,5 +1,5 @@
 /*
- * (C) Copyright IBM Corp. 2025.
+ * (C) Copyright IBM Corp. 2026.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -13,15 +13,7 @@
 
 package com.ibm.cloud.networking.direct_link.v1.model;
 
-import com.ibm.cloud.networking.direct_link.v1.model.AsPrependTemplate;
-import com.ibm.cloud.networking.direct_link.v1.model.AuthenticationKeyIdentityKeyProtectAuthenticationKeyIdentity;
-import com.ibm.cloud.networking.direct_link.v1.model.GatewayBfdConfigTemplate;
-import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakPrototype;
-import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecPrototype;
-import com.ibm.cloud.networking.direct_link.v1.model.GatewayTemplate;
-import com.ibm.cloud.networking.direct_link.v1.model.GatewayTemplateRouteFilter;
-import com.ibm.cloud.networking.direct_link.v1.model.ResourceGroupIdentity;
-import com.ibm.cloud.networking.direct_link.v1.model.SakRekeyPrototypeSakRekeyTimerModePrototype;
+import com.ibm.cloud.networking.direct_link.v1.model.AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -31,16 +23,15 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.*;
 
 /**
- * Unit test class for the GatewayTemplate model.
+ * Unit test class for the AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference model.
  */
-public class GatewayTemplateTest {
+public class AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReferenceTest {
   final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
   final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
 
-  // TODO: Add tests for models that are abstract
   @Test
-  public void testGatewayTemplate() throws Throwable {
-    GatewayTemplate gatewayTemplateModel = new GatewayTemplate();
-    assertNotNull(gatewayTemplateModel);
+  public void testAuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference() throws Throwable {
+    AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference authenticationKeyReferenceSecretsManagerAuthenticationKeyReferenceModel = new AuthenticationKeyReferenceSecretsManagerAuthenticationKeyReference();
+    assertNull(authenticationKeyReferenceSecretsManagerAuthenticationKeyReferenceModel.getCrn());
   }
 }

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/CreateGatewayMacsecCakOptionsTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/CreateGatewayMacsecCakOptionsTest.java
@@ -14,7 +14,7 @@
 package com.ibm.cloud.networking.direct_link.v1.model;
 
 import com.ibm.cloud.networking.direct_link.v1.model.CreateGatewayMacsecCakOptions;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -32,19 +32,19 @@ public class CreateGatewayMacsecCakOptionsTest {
 
   @Test
   public void testCreateGatewayMacsecCakOptions() throws Throwable {
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
-    assertEquals(hpcsKeyIdentityModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
+    assertEquals(hpcsCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
 
     CreateGatewayMacsecCakOptions createGatewayMacsecCakOptionsModel = new CreateGatewayMacsecCakOptions.Builder()
       .id("0a06fb9b-820f-4c44-8a31-77f1f0806d28")
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
     assertEquals(createGatewayMacsecCakOptionsModel.id(), "0a06fb9b-820f-4c44-8a31-77f1f0806d28");
-    assertEquals(createGatewayMacsecCakOptionsModel.key(), hpcsKeyIdentityModel);
+    assertEquals(createGatewayMacsecCakOptionsModel.key(), hpcsCakKeyReferenceModel);
     assertEquals(createGatewayMacsecCakOptionsModel.name(), "1000");
     assertEquals(createGatewayMacsecCakOptionsModel.session(), "primary");
   }

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/CreateGatewayOptionsTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/CreateGatewayOptionsTest.java
@@ -21,7 +21,7 @@ import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakPrototype;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecPrototype;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayTemplateGatewayTypeDedicatedTemplate;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayTemplateRouteFilter;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.ResourceGroupIdentity;
 import com.ibm.cloud.networking.direct_link.v1.model.SakRekeyPrototypeSakRekeyTimerModePrototype;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
@@ -80,17 +80,17 @@ public class CreateGatewayOptionsTest {
       .build();
     assertEquals(resourceGroupIdentityModel.id(), "56969d6043e9465c883cb9f7363e78e8");
 
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
-    assertEquals(hpcsKeyIdentityModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
+    assertEquals(hpcsCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
 
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
-    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsKeyIdentityModel);
+    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsCakKeyReferenceModel);
     assertEquals(gatewayMacsecCakPrototypeModel.name(), "1000");
     assertEquals(gatewayMacsecCakPrototypeModel.session(), "primary");
 

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceTest.java
@@ -1,0 +1,51 @@
+/*
+ * (C) Copyright IBM Corp. 2026.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.ibm.cloud.networking.direct_link.v1.model;
+
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference;
+import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
+import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.List;
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+
+/**
+ * Unit test class for the GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference model.
+ */
+public class GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceTest {
+  final HashMap<String, InputStream> mockStreamMap = TestUtilities.createMockStreamMap();
+  final List<FileWithMetadata> mockListFileWithMetadata = TestUtilities.creatMockListFileWithMetadata();
+
+  @Test
+  public void testGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference() throws Throwable {
+    GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.Builder()
+      .crn("crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222")
+      .build();
+    assertEquals(gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222");
+
+    String json = TestUtilities.serialize(gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceModel);
+
+    GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceModelNew = TestUtilities.deserialize(json, GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.class);
+    assertTrue(gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceModelNew instanceof GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference);
+    assertEquals(gatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceModelNew.crn(), "crn:v1:bluemix:public:secrets-manager:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:secret:bbb222bc-430a-4de9-9aad-84e5bb022222");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testGatewayMacsecCakKeyReferenceSecretsManagerCakKeyReferenceError() throws Throwable {
+    new GatewayMacsecCakKeyReferenceSecretsManagerCakKeyReference.Builder().build();
+  }
+
+}

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPatchTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPatchTest.java
@@ -13,8 +13,8 @@
 
 package com.ibm.cloud.networking.direct_link.v1.model;
 
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakPatch;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -33,33 +33,33 @@ public class GatewayMacsecCakPatchTest {
 
   @Test
   public void testGatewayMacsecCakPatch() throws Throwable {
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
-    assertEquals(hpcsKeyIdentityModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
+    assertEquals(hpcsCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
 
     GatewayMacsecCakPatch gatewayMacsecCakPatchModel = new GatewayMacsecCakPatch.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .build();
-    assertEquals(gatewayMacsecCakPatchModel.key(), hpcsKeyIdentityModel);
+    assertEquals(gatewayMacsecCakPatchModel.key(), hpcsCakKeyReferenceModel);
     assertEquals(gatewayMacsecCakPatchModel.name(), "1000");
 
     String json = TestUtilities.serialize(gatewayMacsecCakPatchModel);
 
     GatewayMacsecCakPatch gatewayMacsecCakPatchModelNew = TestUtilities.deserialize(json, GatewayMacsecCakPatch.class);
     assertTrue(gatewayMacsecCakPatchModelNew instanceof GatewayMacsecCakPatch);
-    assertEquals(gatewayMacsecCakPatchModelNew.key().toString(), hpcsKeyIdentityModel.toString());
+    assertEquals(gatewayMacsecCakPatchModelNew.key().toString(), hpcsCakKeyReferenceModel.toString());
     assertEquals(gatewayMacsecCakPatchModelNew.name(), "1000");
   }
   @Test
   public void testGatewayMacsecCakPatchAsPatch() throws Throwable {
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
 
     GatewayMacsecCakPatch gatewayMacsecCakPatchModel = new GatewayMacsecCakPatch.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .build();
 

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPrototypeTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecCakPrototypeTest.java
@@ -13,8 +13,8 @@
 
 package com.ibm.cloud.networking.direct_link.v1.model;
 
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakPrototype;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
 import java.io.InputStream;
@@ -32,17 +32,17 @@ public class GatewayMacsecCakPrototypeTest {
 
   @Test
   public void testGatewayMacsecCakPrototype() throws Throwable {
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
-    assertEquals(hpcsKeyIdentityModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
+    assertEquals(hpcsCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
 
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
-    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsKeyIdentityModel);
+    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsCakKeyReferenceModel);
     assertEquals(gatewayMacsecCakPrototypeModel.name(), "1000");
     assertEquals(gatewayMacsecCakPrototypeModel.session(), "primary");
 
@@ -50,7 +50,7 @@ public class GatewayMacsecCakPrototypeTest {
 
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModelNew = TestUtilities.deserialize(json, GatewayMacsecCakPrototype.class);
     assertTrue(gatewayMacsecCakPrototypeModelNew instanceof GatewayMacsecCakPrototype);
-    assertEquals(gatewayMacsecCakPrototypeModelNew.key().toString(), hpcsKeyIdentityModel.toString());
+    assertEquals(gatewayMacsecCakPrototypeModelNew.key().toString(), hpcsCakKeyReferenceModel.toString());
     assertEquals(gatewayMacsecCakPrototypeModelNew.name(), "1000");
     assertEquals(gatewayMacsecCakPrototypeModelNew.session(), "primary");
   }

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecPrototypeTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayMacsecPrototypeTest.java
@@ -15,7 +15,7 @@ package com.ibm.cloud.networking.direct_link.v1.model;
 
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakPrototype;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecPrototype;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.SakRekeyPrototypeSakRekeyTimerModePrototype;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
 import com.ibm.cloud.sdk.core.service.model.FileWithMetadata;
@@ -34,17 +34,17 @@ public class GatewayMacsecPrototypeTest {
 
   @Test
   public void testGatewayMacsecPrototype() throws Throwable {
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
-    assertEquals(hpcsKeyIdentityModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
+    assertEquals(hpcsCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
 
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
-    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsKeyIdentityModel);
+    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsCakKeyReferenceModel);
     assertEquals(gatewayMacsecCakPrototypeModel.name(), "1000");
     assertEquals(gatewayMacsecCakPrototypeModel.session(), "primary");
 

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayTemplateGatewayTypeDedicatedTemplateTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/GatewayTemplateGatewayTypeDedicatedTemplateTest.java
@@ -20,7 +20,7 @@ import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakPrototype;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecPrototype;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayTemplateGatewayTypeDedicatedTemplate;
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayTemplateRouteFilter;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.ResourceGroupIdentity;
 import com.ibm.cloud.networking.direct_link.v1.model.SakRekeyPrototypeSakRekeyTimerModePrototype;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
@@ -79,17 +79,17 @@ public class GatewayTemplateGatewayTypeDedicatedTemplateTest {
       .build();
     assertEquals(resourceGroupIdentityModel.id(), "56969d6043e9465c883cb9f7363e78e8");
 
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
-    assertEquals(hpcsKeyIdentityModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
+    assertEquals(hpcsCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
 
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
-    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsKeyIdentityModel);
+    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsCakKeyReferenceModel);
     assertEquals(gatewayMacsecCakPrototypeModel.name(), "1000");
     assertEquals(gatewayMacsecCakPrototypeModel.session(), "primary");
 

--- a/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/SetGatewayMacsecOptionsTest.java
+++ b/modules/direct-link/src/test/java/com/ibm/cloud/networking/direct_link/v1/model/SetGatewayMacsecOptionsTest.java
@@ -14,7 +14,7 @@
 package com.ibm.cloud.networking.direct_link.v1.model;
 
 import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakPrototype;
-import com.ibm.cloud.networking.direct_link.v1.model.HpcsKeyIdentity;
+import com.ibm.cloud.networking.direct_link.v1.model.GatewayMacsecCakKeyReferenceHpcsCakKeyReference;
 import com.ibm.cloud.networking.direct_link.v1.model.SakRekeyPrototypeSakRekeyTimerModePrototype;
 import com.ibm.cloud.networking.direct_link.v1.model.SetGatewayMacsecOptions;
 import com.ibm.cloud.networking.direct_link.v1.utils.TestUtilities;
@@ -34,17 +34,17 @@ public class SetGatewayMacsecOptionsTest {
 
   @Test
   public void testSetGatewayMacsecOptions() throws Throwable {
-    HpcsKeyIdentity hpcsKeyIdentityModel = new HpcsKeyIdentity.Builder()
+    GatewayMacsecCakKeyReferenceHpcsCakKeyReference hpcsCakKeyReferenceModel = new GatewayMacsecCakKeyReferenceHpcsCakKeyReference.Builder()
       .crn("crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222")
       .build();
-    assertEquals(hpcsKeyIdentityModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
+    assertEquals(hpcsCakKeyReferenceModel.crn(), "crn:v1:bluemix:public:hs-crypto:us-south:a/4111d05f36894e3cb9b46a43556d9000:abc111b8-37aa-4034-9def-f2607c87aaaa:key:bbb222bc-430a-4de9-9aad-84e5bb022222");
 
     GatewayMacsecCakPrototype gatewayMacsecCakPrototypeModel = new GatewayMacsecCakPrototype.Builder()
-      .key(hpcsKeyIdentityModel)
+      .key(hpcsCakKeyReferenceModel)
       .name("1000")
       .session("primary")
       .build();
-    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsKeyIdentityModel);
+    assertEquals(gatewayMacsecCakPrototypeModel.key(), hpcsCakKeyReferenceModel);
     assertEquals(gatewayMacsecCakPrototypeModel.name(), "1000");
     assertEquals(gatewayMacsecCakPrototypeModel.session(), "primary");
 


### PR DESCRIPTION
## PR summary
This PR enables Secret Manager support for Direct Link in the Java SDK.

**Fixes:** Secret Manager Enablement for DL – [Issue #202](https://github.ibm.com/NetworkTribe/ui-cli-sdk-terraform-netserv/issues/202)

## PR Checklist
Please make sure that your PR fulfills the following requirements:  
- [x] The commit message follows the [Angular Commit Message Guidelines](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#-commit-message-guidelines).
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type  
<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] New tests
- [ ] Build/CI related changes
- [x] Documentation content changes
- [ ] Other (please describe)

## What is the current behavior?  
<!-- Please describe the current behavior that you are modifying. -->

## What is the new behavior?  
<!-- Please describe the new behavior after your change. -->

## Does this PR introduce a breaking change?    
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Please add any additional information that would help reviewers evaluate your PR -->